### PR TITLE
Make database dumps work with the partitioned version_downloads table.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ dependencies = [
  "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "handlebars 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "htmlescape 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -863,6 +864,11 @@ dependencies = [
  "openssl-sys 0.9.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "h2"
@@ -2877,6 +2883,7 @@ dependencies = [
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum ghost 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5297b71943dc9fea26a3241b178c140ee215798b7f79f7773fd61683e25bca74"
 "checksum git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c7339329bfa14a00223244311560d11f8f489b453fb90092af97f267a6090ab0"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum h2 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ddb2b25a33e231484694267af28fec74ac63b5ccf51ee2065a5e313b834d836e"
 "checksum handlebars 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "df044dd42cdb7e32f28557b661406fc0f2494be75199779998810dbc35030e0d"
 "checksum hashbrown 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e1de41fb8dba9714efd92241565cdff73f78508c95697dd56787d3cba27e2353"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ hyper-tls = "0.3"
 lazy_static = "1.0"
 tokio-core = "0.1"
 diesel_migrations = { version = "1.3.0", features = ["postgres"] }
+glob = "0.3"
 
 [build-dependencies]
 dotenv = "0.15"

--- a/src/tasks/dump_db/dump-db.toml
+++ b/src/tasks/dump_db/dump-db.toml
@@ -34,7 +34,7 @@ private_tables = [
     "readme_renderings",
     "version_owner_actions",
     "versions_published_by",
-    "version_downloads*",
+    "version_downloads_*",
 ]
 
 [tables.badges]
@@ -148,6 +148,20 @@ id = "public"
 version_id = "public"
 user_id = "private"
 name = "public"
+
+[tables.version_downloads]
+# The version_downloads table is partitioned, so the COPY statements used for
+# other tables does not work for this table. By using a filter of "TRUE", we
+# trigger the use of a subquery in the COPY statement:
+#
+#     \copy (SELECT ... FROM "version_downloads" WHERE TRUE) TO ...
+filter = "TRUE"
+dependencies = ["versions"]
+[tables.version_downloads.columns]
+version_id = "public"
+downloads = "public"
+counted = "private"
+date = "public"
 
 [tables.versions]
 dependencies = ["crates", "users"]

--- a/src/tasks/dump_db/dump-db.toml
+++ b/src/tasks/dump_db/dump-db.toml
@@ -2,47 +2,49 @@
 # database table, we set which columns are included in the dump, and optionally
 # how to filter the rows.
 #
-# <table_name>.columns - a TOML dictionary determining what columns to include.
-#     possible values are "private" (not included) and "public" (included).
+# tables.<table_name>.columns - a TOML dictionary determining what columns to
+#     include. possible values are "private" (not included) and "public"
+#     (included).
 #
-# <table_name>.filter - a string that is a valid SQL expression, which is used
-#     in a WHERE clause to filter the rows of the table.
+# tables.<table_name>.filter - a string that is a valid SQL expression, which
+#     is used in a WHERE clause to filter the rows of the table.
 #
-# <table_name>.dependencies - an array of table names, used to determine the
-#     order of the tables in the generated import script. All tables referred
-#     to by public columns in the current table should be listed, to make sure
-#     they are imported before this table.
+# tables.<table_name>.dependencies - an array of table names, used to determine
+#     the order of the tables in the generated import script. All tables
+#     referred to by public columns in the current table should be listed, to
+#     make sure they are imported before this table.
 #
-# <table_name>.columns_defaults - a TOML dictionary mapping column names to a
-#     raw SQL expression that is used as the default value for the column on
-#     import. This is useful for private columns that are not nullable and do
-#     not have a default.
+# tables.<table_name>.columns_defaults - a TOML dictionary mapping column names
+#     to a raw SQL expression that is used as the default value for the column
+#     on import. This is useful for private columns that are not nullable and
+#     do not have a default.
+#
+# private_table - an array of tables to consider as completely private. This is
+#     a shortcut for marking all columns of a table as private.
 
-[api_tokens.columns]
-id = "private"
-user_id = "private"
-token = "private"
-name = "private"
-created_at = "private"
-last_used_at = "private"
-revoked = "private"
+private_tables = [
+    "__diesel_schema_migrations",
+    "api_tokens",
+    "background_jobs",
+    "crate_owner_invitations",
+    "emails",
+    "follows",
+    "publish_limit_buckets",
+    "publish_rate_overrides",
+    "readme_renderings",
+    "version_owner_actions",
+    "versions_published_by",
+    "version_downloads*",
+]
 
-[background_jobs.columns]
-id = "private"
-job_type = "private"
-data = "private"
-retries = "private"
-last_retry = "private"
-created_at = "private"
-
-[badges]
+[tables.badges]
 dependencies = ["crates"]
-[badges.columns]
+[tables.badges.columns]
 crate_id = "public"
 badge_type = "public"
 attributes = "public"
 
-[categories.columns]
+[tables.categories.columns]
 id = "public"
 category = "public"
 slug = "public"
@@ -51,18 +53,10 @@ crates_cnt = "public"
 created_at = "public"
 path = "public"
 
-[crate_owner_invitations.columns]
-invited_user_id = "private"
-invited_by_user_id = "private"
-crate_id = "private"
-created_at = "private"
-token = "private"
-token_generated_at = "private"
-
-[crate_owners]
+[tables.crate_owners]
 dependencies = ["crates", "users"]
 filter = "NOT deleted"
-[crate_owners.columns]
+[tables.crate_owners.columns]
 crate_id = "public"
 owner_id = "public"
 created_at = "public"
@@ -72,7 +66,7 @@ updated_at = "private"
 owner_kind = "public"
 email_notifications = "private"
 
-[crates.columns]
+[tables.crates.columns]
 id = "public"
 name = "public"
 updated_at = "public"
@@ -86,21 +80,21 @@ textsearchable_index_col = "public"
 repository = "public"
 max_upload_size = "public"
 
-[crates_categories]
+[tables.crates_categories]
 dependencies = ["categories", "crates"]
-[crates_categories.columns]
+[tables.crates_categories.columns]
 crate_id = "public"
 category_id = "public"
 
-[crates_keywords]
+[tables.crates_keywords]
 dependencies = ["crates", "keywords"]
-[crates_keywords.columns]
+[tables.crates_keywords.columns]
 crate_id = "public"
 keyword_id = "public"
 
-[dependencies]
+[tables.dependencies]
 dependencies = ["crates", "versions"]
-[dependencies.columns]
+[tables.dependencies.columns]
 id = "public"
 version_id = "public"
 crate_id = "public"
@@ -111,99 +105,53 @@ features = "public"
 target = "public"
 kind = "public"
 
-[__diesel_schema_migrations.columns]
-version = "private"
-run_on = "private"
-
-[emails.columns]
-id = "private"
-user_id = "private"
-email = "private"
-verified = "private"
-token = "private"
-token_generated_at = "private"
-
-[follows.columns]
-user_id = "private"
-crate_id = "private"
-
-[keywords.columns]
+[tables.keywords.columns]
 id = "public"
 keyword = "public"
 crates_cnt = "public"
 created_at = "public"
 
-[metadata.columns]
+[tables.metadata.columns]
 total_downloads = "public"
 
-[publish_limit_buckets.columns]
-user_id = "private"
-tokens = "private"
-last_refill = "private"
-
-[publish_rate_overrides.columns]
-user_id = "private"
-burst = "private"
-
-[readme_renderings.columns]
-version_id = "private"
-rendered_at = "private"
-
-[reserved_crate_names.columns]
+[tables.reserved_crate_names.columns]
 name = "public"
 
-[teams.columns]
+[tables.teams.columns]
 id = "public"
 login = "public"
 github_id = "public"
 name = "public"
 avatar = "public"
 
-[users]
+[tables.users]
 filter = """
 id in (
     SELECT owner_id AS user_id FROM crate_owners WHERE NOT deleted AND owner_kind = 0
     UNION
     SELECT published_by as user_id FROM versions
 )"""
-[users.columns]
+[tables.users.columns]
 id = "public"
 gh_access_token = "private"
 gh_login = "public"
 name = "public"
 gh_avatar = "public"
 gh_id = "public"
-[users.column_defaults]
+[tables.users.column_defaults]
 gh_access_token = "''"
 
-[version_authors]
+[tables.version_authors]
 dependencies = ["versions"]
-[version_authors.columns]
+[tables.version_authors.columns]
 id = "public"
 version_id = "public"
 user_id = "private"
 name = "public"
 
-[version_downloads]
-dependencies = ["versions"]
-[version_downloads.columns]
-version_id = "public"
-downloads = "public"
-counted = "private"
-date = "public"
-processed = "private"
-
-[version_owner_actions.columns]
-id = "private"
-version_id = "private"
-user_id = "private"
-api_token_id = "private"
-action = "private"
-time = "private"
-
-[versions]
+[tables.versions]
 dependencies = ["crates", "users"]
-[versions.columns]
+[tables.versions.columns]
 id = "public"
 crate_id = "public"
 num = "public"
@@ -215,7 +163,3 @@ yanked = "public"
 license = "public"
 crate_size = "public"
 published_by = "public"
-
-[versions_published_by.columns]
-version_id = "private"
-email = "private"

--- a/src/tests/dump_db.rs
+++ b/src/tests/dump_db.rs
@@ -5,7 +5,6 @@ use diesel::{
 };
 
 #[test]
-#[should_panic]
 fn dump_db_and_reimport_dump() {
     let database_url = crate::env("TEST_DATABASE_URL");
 


### PR DESCRIPTION
This change fixes the database dumps for the partitioned version_downloads table introduced in https://github.com/rust-lang/crates.io/pull/2203.

I introduced a `private_tables` setting in the database dump configuration that accepts glob patterns. The list includes the pattern `version_downloads_*`, so all programmatically created partitions should be automatically treated as private, and only the main table `version_downloads` itself is included in the dump.